### PR TITLE
Attack should fire if threshold is reached

### DIFF
--- a/TWANG32/TWANG32.ino
+++ b/TWANG32/TWANG32.ino
@@ -290,7 +290,7 @@ void loop() {
             if(attacking && attackMillis+ATTACK_DURATION < mm) attacking = 0;
 
             // If not attacking, check if they should be
-            if(!attacking && joystickWobble > user_settings.attack_threshold){
+            if(!attacking && joystickWobble >= user_settings.attack_threshold){
                 attackMillis = mm;
                 attacking = 1;
             }


### PR DESCRIPTION
Either we need to modify the getInput example (as it will not trigger the attack by default):

if(digitalRead(attackButtonPinNumber) == HIGH) joystickWobble = ATTACK_THRESHOLD;

Or we can just say, that the user attacks when the threshold is reached (makes it easier to understand if you use alternative input methods).