### PR TITLE
Fixes for new APIs in ESP32-Arduino 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TWANG32
 An ESP32 based, 1D, LED strip, dungeon crawler. inspired by Line Wobbler by Robin B
 
+This version compiles with ESP32-Arduino 3.x.
+
 This was ported from the [TWANG fork](https://github.com/bdring/TWANG) by bdring of [Buildlog.net Blog](http://www.buildlog.net/blog?s=twang)
 
 [![Youtube Video](http://www.buildlog.net/blog/wp-content/uploads/2018/05/vid_thumb.png)](https://www.youtube.com/watch?v=RXpfa-ZvUMA)
@@ -119,8 +121,4 @@ They all call different functions and variables to setup the level. Each one is 
 * speed: The direction and speed of the travel. Negative moves to base and positive moves towards exit. Must be less than +/- max player speed.
 
 **spawnBoss();** (only one, don't edit boss level)
-<<<<<<< HEAD
 * There are no parameters for a boss, they always spawn in the same place and have 3 lives. Tweak the values of Boss.h to modify
-=======
-* There are no parameters for a boss, they always spawn in the same place and have 3 lives. Tweak the values of Boss.h to modify
->>>>>>> origin/master

--- a/TWANG32/TWANG32.ino
+++ b/TWANG32/TWANG32.ino
@@ -29,10 +29,10 @@
 
 // 
 
-#define VERSION "2018-06-28"
+#define VERSION "2024-10-03"
 
 #include <FastLED.h>
-#include<Wire.h>
+#include <Wire.h>
 #include "Arduino.h"
 #include "RunningMedian.h"
 

--- a/TWANG32/sound.h
+++ b/TWANG32/sound.h
@@ -13,9 +13,7 @@
 #include "esp32-hal-timer.h";
 
 #define ESP32_F_CPU         80000000  // the speed of the processor
-#define AUDIO_INTERRUPT_PRESCALER   80 
-#define SOUND_TIMER_NO 0
-//#define AUDIO_PIN 25
+#define AUDIO_INTERRUPT_PRESCALER   80
 #define MIN_FREQ 20
 #define MAX_FREQ 16000
 
@@ -31,12 +29,10 @@ void soundOff();
 
 int dac_pin;
 
-
-
 void IRAM_ATTR onSoundTimer() 
 {    
   if (sound_on) {    
-			dacWrite(dac_pin, (sound_wave_high?sound_volume:0));
+	dacWrite(dac_pin, (sound_wave_high?sound_volume:0));
       sound_wave_high = ! sound_wave_high;
    
   }
@@ -44,16 +40,16 @@ void IRAM_ATTR onSoundTimer()
     dacWrite(dac_pin, 0);
 }
 
+
 void sound_init(int pin){  // pin must be a DAC pin number !! (typically 25 or 26)
   dac_pin = pin;
 	sound_on = false;
 	pinMode(dac_pin, OUTPUT);
 	sound_volume = 0;
-	
-	sndTimer = timerBegin(SOUND_TIMER_NO, AUDIO_INTERRUPT_PRESCALER, true);
-  timerAttachInterrupt(sndTimer, &onSoundTimer, true);          
-  timerAlarmWrite(sndTimer, ESP32_F_CPU/AUDIO_INTERRUPT_PRESCALER/MIN_FREQ, true); // lower timer freq
-  timerAlarmEnable(sndTimer);	
+
+	sndTimer = timerBegin(1000000);
+	timerAttachInterrupt(sndTimer, &onSoundTimer);          
+  timerAlarm(sndTimer, ESP32_F_CPU/AUDIO_INTERRUPT_PRESCALER/MIN_FREQ, true, 0); // lower timer freq
 }
 
 void sound_pause() // this prevents the interrupt from firing ... use during eeprom write
@@ -78,22 +74,15 @@ bool sound(uint16_t freq, uint8_t volume){
 	}
 	sound_on = true;
 	sound_volume = volume;
-  timerAlarmWrite(sndTimer, ESP32_F_CPU/AUDIO_INTERRUPT_PRESCALER/(freq * 2), true);
+  timerAlarm(sndTimer, ESP32_F_CPU/AUDIO_INTERRUPT_PRESCALER/(freq * 2), true, 0);
 	return true;	
 }
 
 void soundOff(){  
  sound_on = false;
  sound_volume = 0;
- timerAlarmWrite(sndTimer, ESP32_F_CPU/AUDIO_INTERRUPT_PRESCALER/(MIN_FREQ), true);  // lower timer freq
+ timerAlarm(sndTimer, ESP32_F_CPU/AUDIO_INTERRUPT_PRESCALER/(MIN_FREQ), true, 0);  // lower timer freq
 }
 
 
-
 #endif
-
-
-
-
-
-

--- a/TWANG32/twang_mpu.h
+++ b/TWANG32/twang_mpu.h
@@ -24,7 +24,7 @@ void Twang_MPU::initialize()
 {
 	Wire.beginTransmission(MPU_ADDR);
 	Wire.write(PWR_MGMT_1);  // PWR_MGMT_1 register
-	Wire.write(0);     // set to zero (wakes up the MPU-6050)
+	Wire.write(1);     // wakes up the MPU-6050
 	Wire.endTransmission(true);
 }
 

--- a/TWANG32/wifi_ap.h
+++ b/TWANG32/wifi_ap.h
@@ -165,7 +165,7 @@ void ap_client_check(){
 				// you're starting a new line
 				currentLineIsBlank = true;
 
-				if (strstr(linebuf,"GET /?") > 0)
+				if (strstr(linebuf,"GET /?") > (char *)0)
 				{
 					String line = String(linebuf);
 


### PR DESCRIPTION
This changeset allows TWANG32 to be compiled with Arduino 2 and ESP32 3.x board definitions.

Changes include rewrites to Timers for sound generation, a fix for MPU-6050 wake up register, and minor fixes for compile time errors.

Note to users: Until this PR is merged use [@marxo/TWANG32](https://github.com/marxo/TWANG32) for flashing with Arduino 2 and ESP32 3.x.